### PR TITLE
HW-262: Remove new mailing styling

### DIFF
--- a/scss/civicrm/mailing/_new-mailing.scss
+++ b/scss/civicrm/mailing/_new-mailing.scss
@@ -1,6 +1,0 @@
-form[name='crmMailing'] {
-  #inputTitle {
-    max-width: 100%;
-    height: 40px;
-  }
-}


### PR DESCRIPTION
No need to use new mailing styling anymore. We replaced this with using "form-group-lg" wrapper class