### PR TITLE
PCHR-2511: Fix ui-select padding

### DIFF
--- a/scss/bootstrap/overrides/_variables.scss
+++ b/scss/bootstrap/overrides/_variables.scss
@@ -345,4 +345,4 @@ $dl-horizontal-offset: 250px !default;
 $blockquote-small-color:      $crm-copy !default;
 $blockquote-border-color:     $brand-primary !default;
 
-$crm-ui-select-top-padding: 4px;
+$crm-ui-select-top-padding: 4px !default;


### PR DESCRIPTION
## Overview
As part of this PR, the `ui-select`dropdown's height has been fixed.

## Before
![manager_leave___hr17-2](https://user-images.githubusercontent.com/5058867/29967786-02afc5ca-8f36-11e7-8590-90338567d510.png)

## After
![manager_leave___hr17-2](https://user-images.githubusercontent.com/5058867/29967811-1e2da312-8f36-11e7-81c0-4884f29646e3.png)

## Technical Details
1. `!default` added to `$crm-ui-select-top-padding`, so that `4px` is used only if the variable is not defined before.