### PR TITLE
PCHR-2584: Do not gulp watch on gulp default task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,7 @@ gulp.task('watch', function () {
   gulp.watch(civicrmScssRoot.getWatchList(), ['sass']);
 });
 
-gulp.task('default', ['sass', 'watch']);
+gulp.task('default', ['sass']);
 
 /**
  * Apply the namespace on html and body elements


### PR DESCRIPTION
## Overview

This PR stops Gulp watching files on `gulp` command. This is made for several reasons:

- Sometimes developers are not sure when all Gulp tasks are completed;
- It is easy to accidentally leave Gulp watching files, checkout to another branch in another repository and sync wrong files as a result;
- Sometimes you would like to simply build distributive files and not watch them;
- There is no TDD process for CSS at the moment.