### PR TITLE
PCHR-2918: Hide labels qhen quicksearch opens on IE11 too

### DIFF
--- a/js/main-menu.js
+++ b/js/main-menu.js
@@ -122,7 +122,7 @@
    */
   function wrapMenuItemLabelInHTML ($menuItem) {
     $menuItem.contents().filter(function () {
-      return this.nodeType === 3 && jQuery(this.parentNode).is($menuItem);
+      return this.nodeType === 3 && $(this).parent().is($menuItem);
     }).wrap('<span class="menumain-label" />')
   }
 }(CRM.$, CRM._));

--- a/js/main-menu.js
+++ b/js/main-menu.js
@@ -122,7 +122,7 @@
    */
   function wrapMenuItemLabelInHTML ($menuItem) {
     $menuItem.contents().filter(function () {
-      return this.nodeType === 3 && jQuery(this.parentElement).is($menuItem);
+      return this.nodeType === 3 && jQuery(this.parentNode).is($menuItem);
     }).wrap('<span class="menumain-label" />')
   }
 }(CRM.$, CRM._));


### PR DESCRIPTION
## Problem
The labels would not get hidden on IE11 when the quickform field is open
![before](https://user-images.githubusercontent.com/6400898/32754426-eabcab98-c8d0-11e7-8e4a-fc62f8d0571b.gif)


## Solution
The JS workaround to wrap the menu item labels in a `<span class="menumain-label">` element used the `parentElement` property of the menu item HTML node, which does not exist in IE. Using the `parentNode` property instead fixes the issue

![after](https://user-images.githubusercontent.com/6400898/32754425-ea9fa390-c8d0-11e7-8eca-6734ade35b65.gif)
