### PR TITLE
PCHR-2922: Focus to quicksearch field when whole block gets clicked

### DIFF
--- a/js/main-menu.js
+++ b/js/main-menu.js
@@ -28,7 +28,18 @@
    */
   function customizeQuickSearchField () {
     changeQuickSearchFieldPlaceholder();
+    giveFocusToQuickSearchFieldWhenBlockGetsClick();
     manageCustomClassOfQuickSearchField();
+  }
+
+  /**
+   * It gives focus to the quicksearch field when a click is registered on the
+   * whole block (= on the icon as well) rather than just the field itself
+   */
+  function giveFocusToQuickSearchFieldWhenBlockGetsClick () {
+    $('#crm-qsearch').click(function () {
+      $('#sort_name_navigation').focus();
+    });
   }
 
   /**


### PR DESCRIPTION
## Problem
The quicksearch field would get the focus only when clicked directly, and not also when the whole quicksearch block (including the icon) would get a click

![before](https://user-images.githubusercontent.com/6400898/32755349-133d0ee2-c8d5-11e7-8034-8fde8c494832.gif)


## Solution
Added a `click` handler that forces the focus on the field when the blocks receives a click

![after](https://user-images.githubusercontent.com/6400898/32755350-182dfb8c-c8d5-11e7-949f-4550710d47cf.gif)
