### PR TITLE
PCHR-3211: Hide labels of menu items with links

### DIFF
--- a/js/main-menu.js
+++ b/js/main-menu.js
@@ -127,13 +127,16 @@
   }
 
   /**
-   * Creates an HTML element out of the text node of the given menu item
+   * Creates an HTML element out of the text node next to the icon (an element
+   * with either the .crm-i or the .fa class) of the given menu item
    *
    * @param {object} $menuItem
    */
   function wrapMenuItemLabelInHTML ($menuItem) {
-    $menuItem.contents().filter(function () {
-      return this.nodeType === 3 && $(this).parent().is($menuItem);
-    }).wrap('<span class="menumain-label" />')
+    var itemLabel = $('.crm-i, .fa', $menuItem)[0].nextSibling;
+
+    if (itemLabel.nodeType === Node.TEXT_NODE) {
+      $(itemLabel).wrap('<span class="menumain-label" />');
+    }
   }
 }(CRM.$, CRM._));


### PR DESCRIPTION
### Problem

After adding the `Reports` link to the CiviHR admin menu, its label didn't get hidden when hovering the Quick Search box:

![reports_menu_before](https://user-images.githubusercontent.com/388373/35866416-48002c12-0b3e-11e8-8d10-daeb53c81f1b.gif)

### Solution

The menu item labels are hidden using CSS. When the user hovers the Quick Search box, the menu receives the `search-ongoing` class, which will make this rule to be applied to each item:

```scss
#civicrm-menu {
  &.search-ongoing {
    .menumain-label {
      max-width: 0;
    }
  }
```
The menu items don't have this `menumain-label` class by default. It's added by the [wrapMenuItemLabelInHTML()](https://github.com/compucorp/org.civicrm.shoreditch/blob/staging/js/main-menu.js#L129-L137) function, when the page is loaded. 

That code seaches for a text node that is a direct child of the menu item and wrap it in a span element with the `menumain-label` class. This works fine for menu items that don't have a link (which was the case of all the items in the menu until today), but it fails when the text node is wrapped in something else (an `a` tag, for example). Now, it assumes that the text node will always be next to the item icon. This way, it first searches for the icon, which can be either a direct child of the menu item or something nested inside another element, then gets the next sibling and, if it's a text note, it wraps with a span with the necessary class:

![reports_menu_after](https://user-images.githubusercontent.com/388373/35866764-26258b7c-0b3f-11e8-801c-139ce4fc5a8c.gif)
