### PR TITLE
PCHR-3124: Delete appraisals extension

### DIFF
--- a/scss/civicrm/contact/_tabs.scss
+++ b/scss/civicrm/contact/_tabs.scss
@@ -92,10 +92,6 @@
           content: '\f0b1';
         }
 
-        &[title='Appraisals']::before {
-          content: '\f200';
-        }
-
         &[title='Assignments']::before {
           content: '\f0f2';
         }


### PR DESCRIPTION
## Overview
`uk.co.compucorp.civicrm.appraisals` extension was previously disabled. This PR completely removes the extension references from shoreditch after extension [removal](https://github.com/compucorp/civihr/pull/2860) implementation.

## Before
Appraisal style exist in the Shoreditch extension

## After
References to the Appraisals styles in  Shoreditch are now removed.

## Technical Details
Style reference was removed
```
&[title='Appraisals']::before {
  content: '\f200';
}
```

