### PR TITLE
PCHR-4188: Style accordions

### DIFF
--- a/scss/bootstrap/overrides/style/_panels.scss
+++ b/scss/bootstrap/overrides/style/_panels.scss
@@ -1,6 +1,7 @@
+//
 .panel {
   @include box-shadow(none);
-  border: none;
+  border: 0;
   margin-bottom: $grid-gutter-width;
 }
 
@@ -13,6 +14,7 @@
 
     // A (temporary?) solution to remove extra spacing in a
     // panel containing an horizontal form
+    /* stylelint-disable max-nesting-depth, selector-max-compound-selectors */
     &.form-horizontal {
       > .row:last-child {
         .form-group {
@@ -20,6 +22,7 @@
         }
       }
     }
+    /* stylelint-enable */
   }
 }
 
@@ -28,7 +31,7 @@
 }
 
 .panel-heading {
-  border: none;
+  border: 0;
 }
 
 .panel-title {
@@ -97,12 +100,6 @@
   > .panel-heading {
     .btn-group-sm {
       margin: -13px 0 -10px 0;
-
-      // TO DO: too much nesting, need to fix this
-      > .btn {
-        padding-left: 20px;
-        padding-right: 20px;
-      }
     }
   }
 
@@ -230,7 +227,7 @@
 
 // TODO: Move it into its own partial, it's not strictly related to panels
 [data-toggle='collapse'] {
-  &:before {
+  &::before {
     @include fa-icon();
     color: inherit;
     content: $fa-var-angle-down;
@@ -238,7 +235,7 @@
     margin-right: 10px;
   }
 
-  &.collapsed:before {
+  &.collapsed::before {
     content: $fa-var-angle-right;
   }
 }

--- a/scss/bootstrap/overrides/style/_panels.scss
+++ b/scss/bootstrap/overrides/style/_panels.scss
@@ -38,6 +38,16 @@
   font-size: $font-size-h2;
   font-weight: $crm-font-weight-h2;
   line-height: $headings-line-height;
+
+  a {
+    text-decoration: none !important;
+  }
+
+  [data-toggle='collapse'][aria-expanded='false'] {
+    &::before {
+      content: $fa-var-angle-right;
+    }
+  }
 }
 
 .panel-title-sm {
@@ -107,6 +117,14 @@
     background: $panel-default-heading-bg;
     border-top-color: $gray-light;
     color: $panel-default-text;
+  }
+
+  &.panel-w-vertical-tabs {
+    .panel-body {
+      background: transparent;
+      border-top: 0 !important;
+      padding: 0;
+    }
   }
 
   // Status strips

--- a/scss/bootstrap/overrides/style/_panels.scss
+++ b/scss/bootstrap/overrides/style/_panels.scss
@@ -14,9 +14,7 @@
     // A (temporary?) solution to remove extra spacing in a
     // panel containing an horizontal form
     &.form-horizontal {
-
       > .row:last-child {
-
         .form-group {
           margin-bottom: 0;
         }
@@ -58,11 +56,11 @@
 // Subheading and subtitle
 .panel-subheading {
 
+  padding: $crm-panel-subheading-padding;
+
   .panel-heading + & {
     border-top: 1px solid transparent;
   }
-
-  padding: $crm-panel-subheading-padding;
 }
 
 .panel-subtitle {
@@ -97,7 +95,6 @@
   }
 
   > .panel-heading {
-
     .btn-group-sm {
       margin: -13px 0 -10px 0;
 
@@ -116,7 +113,7 @@
   }
 
   // Status strips
-  &[class*="panel-strip-"] {
+  &[class*='panel-strip-'] {
     border-left: $crm-panel-status-strip-width solid transparent;
   }
 
@@ -142,61 +139,56 @@
 }
 
 .panel-primary {
-
   > .panel-subheading {
-    background: $panel-primary-heading-bg;
-    color: $panel-primary-text;
-    border-top-color: $panel-info-border;
 
     @include shadow-mask($panel-primary-heading-bg, 'top', -11px);
+    background: $panel-primary-heading-bg;
+    border-top-color: $panel-info-border;
+    color: $panel-primary-text;
   }
 }
 
 .panel-success {
-
   > .panel-heading {
     color: $gray-darker;
   }
 
   > .panel-subheading {
-    background: $panel-success-heading-bg;
-    color: $panel-success-text;
-    border-top-color: $panel-success-border;
 
     @include shadow-mask($panel-success-heading-bg, 'top', -11px);
+    background: $panel-success-heading-bg;
+    border-top-color: $panel-success-border;
+    color: $panel-success-text;
   }
 }
 
 .panel-info {
-
   > .panel-subheading {
-    background: $panel-info-heading-bg;
-    color: $panel-info-text;
-    border-top-color: $panel-info-border;
 
     @include shadow-mask($panel-info-heading-bg, 'top', -11px);
+    background: $panel-info-heading-bg;
+    border-top-color: $panel-info-border;
+    color: $panel-info-text;
   }
 }
 
 .panel-warning {
-
   > .panel-subheading {
-    background: $panel-warning-heading-bg;
-    color: $panel-warning-text;
-    border-top-color: $panel-warning-border;
 
     @include shadow-mask($panel-warning-heading-bg, 'top', -11px);
+    background: $panel-warning-heading-bg;
+    border-top-color: $panel-warning-border;
+    color: $panel-warning-text;
   }
 }
 
 .panel-danger {
-
   > .panel-subheading {
-    background: $panel-danger-heading-bg;
-    color: $panel-danger-text;
-    border-top-color: $panel-danger-border;
 
     @include shadow-mask($panel-danger-heading-bg, 'top', -11px);
+    background: $panel-danger-heading-bg;
+    border-top-color: $panel-danger-border;
+    color: $panel-danger-text;
   }
 }
 
@@ -205,7 +197,6 @@
 .panel-info,
 .panel-warning,
 .panel-danger {
-
   > .panel-body,
   > .panel-footer,
   > .panel-heading,
@@ -231,7 +222,6 @@
 
 // Panel heading with buttons, aligned vertically
 .panel-heading-w-buttons {
-
   .btn {
     margin: -8px 0 -8px 10px;
   }
@@ -239,8 +229,7 @@
 
 
 // TODO: Move it into its own partial, it's not strictly related to panels
-[data-toggle="collapse"] {
-
+[data-toggle='collapse'] {
   &:before {
     @include fa-icon();
     color: inherit;


### PR DESCRIPTION
## Overview

This PR add styles for `uib-accordion` directive:
- It fixes the chevron
- It removes the underlining of `<a>` element in the header

It also fixes styling for vertically stacked navigation inside the collapsible panel.

Made for https://github.com/compucorp/civihr/pull/2865.

## Before

![image](https://user-images.githubusercontent.com/3973243/46362765-13bfc200-c669-11e8-81bf-4a7e06759871.png)

## After

![image](https://user-images.githubusercontent.com/3973243/46362746-06a2d300-c669-11e8-9280-4cf4ab4954ae.png)

## Technical description

```css
  /* removes underlining */
  a {
    text-decoration: none !important;
  }
  /* fixes chevron so it looks right when panel is collapsed */
   [data-toggle='collapse'][aria-expanded='false'] {
    &::before {
      content: $fa-var-angle-right;
    }
  }

  /* fixes the style for the nested stacked nav */
  &.panel-w-vertical-tabs {
    .panel-body {
      background: transparent;
      border-top: 0 !important;
      padding: 0;
    }
  }
```

### Comments

BackstopJS tests were suppressed because that would take a lot of time to run and it is very unlikely that the changes will affect anything globally.

----
✅Manual Tests - passed
✅CSS distributive files - included
⏹Backstop tests - suppressed