### PR TITLE
PCHR-4280: Fix profile picture script

### DIFF
--- a/js/contact-summary.js
+++ b/js/contact-summary.js
@@ -21,9 +21,8 @@
      */
     function moveUserPictureNextToContactTitle () {
       var header = document.querySelector('.crm-summary-contactname-block');
-      var block = document.querySelector('.crm-summary-block');
 
-      header.insertBefore(picWrapper, block);
+      header.insertBefore(picWrapper, header.firstElementChild);
     }
 
     /**


### PR DESCRIPTION
## Problem
Shoreditch moves the profile picture (when present) from the Personal Details tab to the contact summary page header. It does so by taking the `#crm-contact-thumbnail` element and moving it right before the `.crm-summary-block` element
```js
function moveUserPictureNextToContactTitle () {
  var header = document.querySelector('.crm-summary-contactname-block');
  var block = document.querySelector('.crm-summary-block');

  header.insertBefore(picWrapper, block);
}
```
This works fine on standard CiviCRM sites, but in CiviHR the header markup is slightly different: the `.crm-summary-block` element gets wrapped in a custom `.crm-summary-block-wrap` element
```html
<!-- CiviCRM -->
<div class="crm-summary-contactname-block">
  <!-- This line is where the #crm-contact-thumbnail should be placed -->
  <div class="crm-summary-block" id="contactname-block"></div>
</div>
```
```html
<!-- CiviHR -->
<div class="crm-summary-contactname-block">
  <!-- This line is where the #crm-contact-thumbnail should be placed -->
  <div class="crm-summary-block-wrap">
    <div class="crm-summary-block" id="contactname-block"></div>
  </div>
</div>
```
So when executing
```js
header.insertBefore(picWrapper, block);
```
an error is thrown
```js
Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
```
<img width="700" alt="error" src="https://user-images.githubusercontent.com/6400898/46544714-a0b28780-c8c4-11e8-93fb-2b1524cab767.png">

that is: in CiviHR `.crm-summary-block` is not a direct child of `.crm-summary-contactname-block`

## Solution
Instead of explicitly referring the reference node, using the `.firstElementChild` property make the script work in both CiviCRM and CiviHR
```js
function moveUserPictureNextToContactTitle () {
  var header = document.querySelector('.crm-summary-contactname-block');

  header.insertBefore(picWrapper, header.firstElementChild);
}
```
<img width="701" alt="fixed" src="https://user-images.githubusercontent.com/6400898/46544731-a60fd200-c8c4-11e8-9b12-41fc6e4800f2.png">
