### PR TITLE
PCHR-4191: Fix checkbox switch vertical offset

### DIFF
--- a/scss/bootstrap/variants/_checkbox-switch.scss
+++ b/scss/bootstrap/variants/_checkbox-switch.scss
@@ -1,4 +1,5 @@
 .checkbox-switch {
+  margin-top: $crm-btn-padding-small-vertical !important;
   padding-top: 0 !important;
   position: relative;
 

--- a/scss/bootstrap/variants/_checkbox-switch.scss
+++ b/scss/bootstrap/variants/_checkbox-switch.scss
@@ -1,6 +1,4 @@
 .checkbox-switch {
-  margin-top: $crm-btn-padding-small-vertical !important;
-  padding-top: 0 !important;
   position: relative;
 
   input {
@@ -12,6 +10,10 @@
     top: 0;
     visibility: hidden;
     width: 0;
+  }
+
+  label {
+    min-height: auto;
   }
 
   /* Context (colours) */
@@ -84,8 +86,8 @@
     background-clip: padding-box;
     background-color: $crm-white;
     border: solid transparent $crm-checkbox-switch-gap;
+    bottom: 0;
     display: block;
-    top: 0;
     transition: margin-left ($crm-checkbox-switch-speed / 2) ease-in-out;
     width: $crm-checkbox-switch-size-normal;
   }


### PR DESCRIPTION
## Overview

This PR adds a top margin to the switcher. This is consistent with the native bootstrap checkbox. This makes the switch be aligned with labels.

This PR is needed for https://github.com/compucorp/civihr/pull/2880

## Before 

![image](https://user-images.githubusercontent.com/3973243/47025994-6b2b5b00-d15c-11e8-937a-f231557756e6.png)

## After 

![image](https://user-images.githubusercontent.com/3973243/47025958-5b137b80-d15c-11e8-9f7e-e056be13ba14.png)

### Styleguide

![image](https://user-images.githubusercontent.com/3973243/47077865-d119f000-d1f9-11e8-9b43-4397d6bae1dc.png)


### Technical details

```css
/* Override Vanilla Bootstrap label min-height */
.checkbox-switch {
  label {
    min-height: auto;

/* Change top to bottom to disregard any paddings or margins */

.checkbox-switch-label {
  // ...

  &::after {
    // ...
    bottom: 0;
```

-----

✅Manual Tests - passed
⏹Backstop tests - suppressed because the switch is not yet used anywhere