### PR TITLE
PCHR-4355: Fix imports

### DIFF
--- a/scss/bootstrap/overrides/style/_modals.scss
+++ b/scss/bootstrap/overrides/style/_modals.scss
@@ -45,5 +45,3 @@
     top: initial !important;
   }
 }
-
-@import 'bootstrap/variants/modals-xs-screen';

--- a/scss/bootstrap/variants/_outlined-buttons.scss
+++ b/scss/bootstrap/variants/_outlined-buttons.scss
@@ -2,8 +2,6 @@
 
 .btn-default-outline {
   @include button-outline-variant($crm-white);
-  border-color: $crm-white !important;
-  color: $crm-white !important;
 
   .open &,
   &:hover,

--- a/scss/bootstrap/variants/_outlined-buttons.scss
+++ b/scss/bootstrap/variants/_outlined-buttons.scss
@@ -1,6 +1,4 @@
-@import 'bootstrap/mixins/button-outline-variant';
-@import 'bootstrap/mixins/hover';
-@import 'bootstrap/overrides/variables';
+@import '../overrides/variables';
 
 .btn-default-outline {
   @include button-outline-variant($crm-white);

--- a/scss/jquery/overrides/_ui-dialog.scss
+++ b/scss/jquery/overrides/_ui-dialog.scss
@@ -1,4 +1,4 @@
-@import 'jquery/mixins/ui-dialog';
+@import '../jquery/mixins/ui-dialog';
 
 .ui-dialog {
   @include ui-dialog;


### PR DESCRIPTION
As part of https://github.com/civicrm/org.civicrm.shoreditch/pull/315, the `@import` paths had been changed so that they always start with the base folder (`base/`, `bootstrap/`, `civicrm/`, see https://github.com/civicrm/org.civicrm.shoreditch/pull/315/commits/489bee34bdd50e3ab3879d74238983d4b111c02d). Those folders are then resolved via the `includePaths` option of `gulp-sass`

```js
var includePaths = [
  __dirname,
  path.join(__dirname, 'scss')
];

.pipe(sass({
  includePaths: includePaths,
})
```

This setup works fine when compiling Shoreditch itself, but causes an error when compiling said partials as part of a different theme like https://github.com/compucorp/civihr-employee-portal-theme.

The employee portal theme references plenty of Shoreditch's partials (see [L113-L128](https://github.com/compucorp/civihr-employee-portal-theme/blob/master/civihr_default_theme/scss/civihr_default_theme.style.scss) for example), but it also sets its own value for `gulp-sass`'s `includePaths` (see [here](https://github.com/compucorp/civihr-employee-portal-theme/blob/master/civihr_default_theme/gulpfile.js#L42))

This means that when `gulp-sass` of the employee portal theme tries to import a partial like https://github.com/compucorp/org.civicrm.shoreditch/blob/2a4f9c877978ebf8f2fb613b294f6eb26fb24f48/scss/bootstrap/variants/_outlined-buttons.scss that has the following `@import`s itself:
```scss
@import 'bootstrap/mixins/button-outline-variant';
@import 'bootstrap/mixins/hover';
@import 'bootstrap/overrides/variables';
```
it doesn't know how to resolve the `bootstrap/` folder and errors out
```
12:52:04] gulp-notify: [Gulp] Error: ../../../../default/files/civicrm/templates_c/SCSSROOT/org.civicrm.shoredit
ch/scss/bootstrap/variants/_outlined-buttons.scss
Error: File to import not found or unreadable: bootstrap/mixins/button-outline-variant.
        on line 1 of ../../../../default/files/civicrm/templates_c/SCSSROOT/org.civicrm.shoreditch/scss/bootstrap
/variants/_outlined-buttons.scss
        from line 37 of scss/civihr_default_theme.style.scss
>> @import 'bootstrap/mixins/button-outline-variant';
```

A simple solution is to revert back to using relative paths in the partials, so that they can be safely be included outside of Shoreditch

### Additional notes
The following `@import`s had been removed from `_outlined-buttons.scss`
```scss
@import 'bootstrap/mixins/button-outline-variant';
@import 'bootstrap/mixins/hover';
```
given that those mixins are already being imported both in Shoreditch and the employee portal theme

---

The following properties had been removed from `.btn-default-outline`, see [this comment](https://github.com/compucorp/org.civicrm.shoreditch/pull/135#discussion_r229676147) for additional details on when those lines were introduced and on how the changes were tested
```scss
border-color: $crm-white !important;
color: $crm-white !important;
```

---

The following `@import` had been removed from `overrides/style/_modals.scss`
```scss
@import 'bootstrap/variants/modals-xs-screen';
```
given that that variant is being imported both in Shoreditch and the employee portal theme

